### PR TITLE
Update README.md to show more information for status polling states

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This [homebridge](https://github.com/nfarina/homebridge) plugin exposes a web-ba
 | `switchOffDelay` | Time (in seconds) until your garage will automatically close without animation (if enabled) | `2` |
 | `polling` | Whether the state should be polled at intervals | `false` |
 | `pollInterval` | Time (in seconds) between device polls (if `polling` is enabled) | `120` |
-| `statusURL` | URL to retrieve state on poll (should return `0` or `1`) | N/A |
+| `statusURL` | URL to retrieve state on poll (should return `0` for open, `1` for closed, `2` for opening, `3` for closing, and `4` for stopped midway) | N/A |
 
 ### Additional options
 | Key | Description | Default |


### PR DESCRIPTION
Based on how the status is polled in the current code, the status URL can return any valid value for characteristic 9.30 Current Door State.